### PR TITLE
Fixes for message_type_support_struct changes

### DIFF
--- a/rmw_freertps_cpp/src/functions.cpp
+++ b/rmw_freertps_cpp/src/functions.cpp
@@ -27,8 +27,6 @@
 #include "rmw/impl/cpp/macros.hpp"
 #include "rmw/rmw.h"
 
-#include "rosidl_generator_c/message_type_support.h"
-#include "rosidl_generator_c/service_type_support.h"
 #include "rosidl_typesupport_freertps_cpp/identifier.hpp"
 #include "rosidl_typesupport_freertps_cpp/message_type_support.h"
 #include "rosidl_typesupport_freertps_cpp/service_type_support.h"

--- a/rosidl_typesupport_freertps_cpp/cmake/rosidl_typesupport_freertps_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_freertps_cpp/cmake/rosidl_typesupport_freertps_cpp_generate_interfaces.cmake
@@ -127,6 +127,7 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_freertps_cpp
+  include
   include/${PROJECT_NAME}/impl
   "${_output_path}/msg/freertps"
   "${_output_path}/srv/freertps"

--- a/rosidl_typesupport_freertps_cpp/include/rosidl_typesupport_freertps_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
+++ b/rosidl_typesupport_freertps_cpp/include/rosidl_typesupport_freertps_cpp/impl/rosidl_generator_cpp/message_type_support.hpp
@@ -19,7 +19,7 @@
 #define ROSIDL_TYPESUPPORT_FREERTPS_CPP__IMPL__ROSIDL_GENERATOR_CPP__MESSAGE_TYPE_SUPPORT_HPP_
 
 // Provides the definition of the rosidl_message_type_support_t struct.
-#include <rosidl_generator_c/message_type_support.h>
+#include <rosidl_generator_c/message_type_support_struct.h>
 // Provides the declaration of the function
 // rosidl_generator_cpp::get_message_type_support_handle.
 #include <rosidl_generator_cpp/message_type_support_decl.hpp>

--- a/rosidl_typesupport_freertps_cpp/resource/msg__type_support.cpp.template
+++ b/rosidl_typesupport_freertps_cpp/resource/msg__type_support.cpp.template
@@ -23,7 +23,6 @@ extern "C"
 #include "freertps/freertps.h"
 }
 
-#include "rosidl_generator_c/message_type_support.h"
 // this is defined in the rosidl_typesupport_freertps_cpp package and
 // is in the include/rosidl_typesupport_freertps_cpp/impl folder
 #include "rosidl_generator_cpp/message_type_support.hpp"


### PR DESCRIPTION
Right now master does not compile.

With this change, it does.
